### PR TITLE
Fix no sound bug, after click very fast.

### DIFF
--- a/index.js
+++ b/index.js
@@ -681,7 +681,7 @@ export default e => {
   useFrame(() => {
     const localPlayer = useLocalPlayer();
     if(localPlayer.avatar && wearing){
-      if(localPlayer.avatar.useAnimationIndex !== lastPlaySoundAnimationIndex){
+      if(localPlayer.avatar.useAnimationIndex >= 0 && localPlayer.avatar.useAnimationIndex !== lastPlaySoundAnimationIndex){
         if(startAnimationTime===0){
           startAnimationTime=performance.now();
         }


### PR DESCRIPTION
Fix bug introduced by https://github.com/webaverse/silsword/pull/5 .
If click very fast, will caused `playSoundSw` always `true`, then never play sound again.